### PR TITLE
Validate ring settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ The project is designed to be educational and released in the hope it will be us
 
 ## Enigma Machine Variants
 
-|Supported|Short Name|No. of Rotors|Reflector|Plugboard|Decription|
-|---------|----------|-------------|---------|---------|----------|
-| Y       |	Enigma1  | 3           | fixed position | optional | The main Enigma machine used by the German Army |
-| Y       | M3       | 3      	   | fixed position | optional | used by the German Navy (Kriegsmarine). |
-| N       | M4       | 4      	   | fixed position | Yes | Used exclusively by the U-boat division of the German Navy (Kriegsmarine)|
-| N       | Swiss-K  | 3           | settable, not rotating | No | All Enigma K machines were delivered by the Germans with the standard commercial wheel wiring, also known from the Enigma D |
-| N       |	Enigma KD | 3          | settable, not rotating | No | A standard commercial Enigma K machine with a rewirable reflector (UKW-D). |
-| N       |	Railway | 3            | settable, not rotating | No | During WWII, the Germans used a special Enigma machine for the German Railway (Reichsbahn). |
-| N       |	Tirpitz | 3            | settable, not rotating | No | The Enigma T (Tirpitz) was a special version of the Enigma K that was made for the Japanese Army during WWII. |
-| N       |	Zählwerk | 3            | settable, and rotating | No | The Enigma T (Tirpitz) was a special version of the Enigma K that was made for the Japanese Army during WWII. |
+Implemented|Supported|Short Name|No. of Rotors|Reflector|Plugboard|Decription|
+---------|---------|----------|-------------|---------|---------|----------|
+|N| Y       |	Enigma1  | 3           | fixed position | optional | The main Enigma machine used by the German Army |
+|N| Y       | M3       | 3      	   | fixed position | optional | used by the German Navy (Kriegsmarine). |
+|N| N       | M4       | 4      	   | fixed position | Yes | Used exclusively by the U-boat division of the German Navy (Kriegsmarine)|
+|N| N       | Swiss-K  | 3           | settable, not rotating | No | All Enigma K machines were delivered by the Germans with the standard commercial wheel wiring, also known from the Enigma D |
+|N| N       |	Enigma KD | 3          | settable, not rotating | No | A standard commercial Enigma K machine with a rewirable reflector (UKW-D). |
+|N| N       |	Railway | 3            | settable, not rotating | No | During WWII, the Germans used a special Enigma machine for the German Railway (Reichsbahn). |
+|N| N       |	Tirpitz | 3            | settable, not rotating | No | The Enigma T (Tirpitz) was a special version of the Enigma K that was made for the Japanese Army during WWII. |
+|N| N       |	Zählwerk | 3            | settable, and rotating | No | The Enigma T (Tirpitz) was a special version of the Enigma K that was made for the Japanese Army during WWII. |

--- a/src/libEnigmaSimulator/EnigmaMachine.cpp
+++ b/src/libEnigmaSimulator/EnigmaMachine.cpp
@@ -145,7 +145,7 @@ namespace enigmaSimulator {
 
             // Get substituted letter from each rotor. The returned value will
             // take into account the position of the rotor.
-            currentLetter = rotor->second->Encrypt (currentLetter);
+            currentLetter = rotor->second->EncryptForward (currentLetter);
 
             TraceLog(kLogLevel_trace,
                 "=> Input : '%c' (%d) | Output : '%c' (%d)",
@@ -176,7 +176,7 @@ namespace enigmaSimulator {
             TraceLog(kLogLevel_trace, "<==== ROTOR '%s' ====>",
                 rotor->second->RotorName ().c_str ());
             auto oldLetter = currentLetter;
-            currentLetter = rotor->second->Encrypt (currentLetter, false);
+            currentLetter = rotor->second->EncryptReverse (currentLetter);
 
             TraceLog(kLogLevel_trace,
                 "=> Input : '%c' (%d) | Output : '%c' (%d)",

--- a/src/libEnigmaSimulator/IRotor.h
+++ b/src/libEnigmaSimulator/IRotor.h
@@ -47,9 +47,9 @@ namespace enigmaSimulator {
 
         virtual void Step () = 0;
 
-        virtual RotorContact Encrypt (
-            RotorContact contact,
-            bool forward = true) = 0;
+        virtual RotorContact EncryptForward (RotorContact contact) = 0;
+
+        virtual RotorContact EncryptReverse (RotorContact contact) = 0;
 
         virtual bool WillStepNext () = 0;
 

--- a/src/libEnigmaSimulator/Rotor.cpp
+++ b/src/libEnigmaSimulator/Rotor.cpp
@@ -122,12 +122,13 @@ namespace enigmaSimulator {
                   "=> Current Rotor position : '%c' (%d) is offset by %d",
             RotorContactStr[rotor_position_], rotor_position_, rotor_offset);
 
-        // STEP 1: Correct the input contact entrypoint for position
+        // Correct the input contact entrypoint for position
         auto contact_position = OffsetContactPosition (
             contact, rotor_position_ - kRotorContact_A);
 
         RotorContact output_contact = kRotorContact_end;
 
+        // Get the destination, in this case the 'source'.
         output_contact = wiring_.WiringPathReverse (contact_position);
         DebugLog( "Rotor::EncryptReverse",
             "=> Backwards destination contact for '%c' (%d) : '%c' (%d)",

--- a/src/libEnigmaSimulator/Rotor.cpp
+++ b/src/libEnigmaSimulator/Rotor.cpp
@@ -54,100 +54,95 @@ namespace enigmaSimulator {
     void Rotor::Step ()
     {
         rotor_position_ = RotorContact((rotor_position_ + 1) % MAX_CONTACT_NO);
+        RecalculateWiring ();
     }
 
-    RotorContact Rotor::Encrypt (RotorContact contact, bool forward)
+    /*
+    Encrypt a character forward.
+
+    Example 1
+    'A' is pressed with the rotor in position 1 ('A'), it will returns the
+    output from 'A'. Enigma Rotor 1 will return 'E' for letter 'A'.
+
+    Example 2
+    'A' is pressed with the rotor in position 2 ('B'), it will return the
+    output from 'B' ('A' has been moved on 1 as rotor is in position 'B').
+    Enigma Rotor 1 will return 'K' for a letter 'B'
+    */
+    RotorContact Rotor::EncryptForward (RotorContact contact)
     {
-        /*
-        Encrpyting a character is done in three stages:
+        int rotor_offset = rotor_position_ - kRotorContact_A;
+        DebugLog( "Rotor::EncryptForward", "=> [%s] Input Contact '%c' (%d)",
+             rotor_name_.c_str(), RotorContactStr[contact], contact);
+        DebugLog( "Rotor::EncryptForward",
+                  "=> Current Rotor position : '%c' (%d) (offset : %d)",
+            RotorContactStr[rotor_position_], rotor_position_, rotor_offset);
 
-        === STEP 1 ===
-        Correct the input contact entrypoint for position :
-        Take into account the current position of the rotor and determine if it
-        has wrapped past the letter 'Z'.
+        auto contact_position = contact;
 
-        Example 1
-        'A' is pressed with the rotor in position 1 ('A'), it will returns the
-        output from 'A'. Enigma Rotor 1 will return 'E' for letter 'A'.
+        RotorContact output_contact = kRotorContact_end;
 
-        Example 2
-        'A' is pressed with the rotor in position 2 ('B'), it will return the
-        output from 'B' ('A' has been moved on 1 as rotor is in position 'B').
-        Enigma Rotor 1 will return 'K' for a letter 'B'
+        output_contact = wiring_.WiringPathForward (contact_position);
+        DebugLog( "Rotor::EncryptForward", "=> Destination : '%c' (%d)",
+            RotorContactStr[output_contact], output_contact);
 
-        === STEP 2 ===
-        Take rotor offset into account
-        When a rotor has stepped, the offset must be taken into account when it
-        comes to the output and the entrypoint of the next rotor.
+        rotor_offset = -(rotor_position_ - kRotorContact_A);
+        DebugLog( "Rotor::EncryptForward",
+            "=> Adjusting destination rotor for offset : '%c' (%d) by %d",
+        RotorContactStr[output_contact], output_contact, rotor_offset);
 
-        Example 1
-        'A' is pressed with the rotor in 'B' (1) position, it will return the
-        output from 'B' as rotor is in position 'B', e.g.Enigma Rotor 1 will
-        return 'K' for 'B', but as the rotor is in position 'B' (forward 1) the
-        exit position is offset by 1 which means 'J' is returned.
-
-        Example 2
-        'Z' is pressed with the rotor in 'B' (1) position, it will return the
-        output from 'A' as rotor is in position 'B' and this then wraps ('Z'
-        forward 1 = 'A'), e.g.Enigma Rotor 1 will return 'E' for a letter 'A',
-        but the rotor is in position 'B' (forward 1) so 'J' is returned.
-        */
-
+        output_contact = OffsetContactPosition (
+            output_contact, -(rotor_position_ - kRotorContact_A));
         DebugLog( "Rotor::" + std::string(__func__),
-                  "=> Contact '%c' (%d) | rotor : '%s' | forward : %d",
-            RotorContactStr[contact], contact, rotor_name_.c_str(), forward);
+            "=> Outgoing Rotor position = '%c' (%d)",
+        RotorContactStr[output_contact], output_contact);
+
+        return output_contact;
+    }
+
+    /*
+    Encrypt a character in reverse.
+
+    Example 1
+    'A' is pressed with the rotor in position 1 ('A'), it will returns the
+    output from 'A'. Enigma Rotor 1 will return 'E' for letter 'A'.
+
+    Example 2
+    'A' is pressed with the rotor in position 2 ('B'), it will return the
+    output from 'B' ('A' has been moved on 1 as rotor is in position 'B').
+    Enigma Rotor 1 will return 'K' for a letter 'B'
+    */
+    RotorContact Rotor::EncryptReverse (RotorContact contact)
+    {
+        int rotor_offset = rotor_position_ - kRotorContact_A;
+        DebugLog( "Rotor::EncryptReverse",
+                  "=> Contact '%c' (%d) | rotor : '%s'",
+            RotorContactStr[contact], contact, rotor_name_.c_str());
         DebugLog( "Rotor::" + std::string(__func__),
                   "=> Current Rotor position : '%c' (%d) is offset by %d",
-            RotorContactStr[rotor_position_], rotor_position_,
-            rotor_position_ - kRotorContact_A);
+            RotorContactStr[rotor_position_], rotor_position_, rotor_offset);
 
         // STEP 1: Correct the input contact entrypoint for position
         auto contact_position = OffsetContactPosition (
             contact, rotor_position_ - kRotorContact_A);
 
-        DebugLog( "Rotor::" + std::string(__func__),
-                  "|==== STEP 1: Correct input contact with rotor position ====|");
-        DebugLog( "Rotor::" + std::string(__func__),
-            "=> Contact after position correction rotor : '%c' (%d) => '%c' (%d)",
-            RotorContactStr[contact],
-            contact,
-            RotorContactStr[contact_position],
-            contact_position);
-
         RotorContact output_contact = kRotorContact_end;
 
-        if (forward)
-        {
-            output_contact = wiring_.WiringPathForward (contact_position);
-            DebugLog( "Rotor::" + std::string(__func__),
-                "=> Forward destination contact for '%c' (%d) : '%c' (%d)",
-                RotorContactStr[contact_position],
-                contact_position,
-                RotorContactStr[output_contact],
-                output_contact);
-        }
-        else
-        {
-            output_contact = wiring_.WiringPathReverse (contact_position);
-            DebugLog( "Rotor::" + std::string(__func__),
-                "=> Backwards destination contact for '%c' (%d) : '%c' (%d)",
-                RotorContactStr[contact_position],
-                contact_position,
-                RotorContactStr[output_contact],
-                output_contact);
-        }
+        output_contact = wiring_.WiringPathReverse (contact_position);
+        DebugLog( "Rotor::EncryptReverse",
+            "=> Backwards destination contact for '%c' (%d) : '%c' (%d)",
+            RotorContactStr[contact_position],
+            contact_position,
+            RotorContactStr[output_contact],
+            output_contact);
 
-        DebugLog( "Rotor::" + std::string(__func__),
-            "|==== STEP 2: Correct input contact with rotor offset ====|");
-
-        // STEP 3: Take rotor offset into account
-        DebugLog( "Rotor::" + std::string(__func__),
+        DebugLog( "Rotor::EncryptReverse",
             "=> Adjusting destination rotor for offset : '%c' (%d) by %d",
         RotorContactStr[output_contact], output_contact, -rotor_position_);
 
         output_contact = OffsetContactPosition (
             output_contact, -(rotor_position_ - kRotorContact_A));
-        DebugLog( "Rotor::" + std::string(__func__),
+        DebugLog( "Rotor::EncryptReverse",
             "=> Outgoing Rotor position = '%c' (%d)",
         RotorContactStr[output_contact], output_contact);
 

--- a/src/libEnigmaSimulator/Rotor.cpp
+++ b/src/libEnigmaSimulator/Rotor.cpp
@@ -76,9 +76,6 @@ namespace enigmaSimulator {
         Enigma Rotor 1 will return 'K' for a letter 'B'
 
         === STEP 2 ===
-        Take ring settings into account : CURRENTLY NOT IMPLEMENTED
-
-        === STEP 3 ===
         Take rotor offset into account
         When a rotor has stepped, the offset must be taken into account when it
         comes to the output and the entrypoint of the next rotor.
@@ -141,27 +138,7 @@ namespace enigmaSimulator {
         }
 
         DebugLog( "Rotor::" + std::string(__func__),
-            "|==== STEP 2: Correct input contact with ring position ====|");
-        // STEP 2: Correct input contact using ring position
-        // Ring positions are not implemented - untested code
-
-#ifdef __USE_UNTESTED_CODE__
-        if self.__ringSetting > 1:
-            outputPin = outputPin + (self.__ringSetting -1)
-
-        if (outputPin - (self.__ringSetting -1)) <= 0:
-            outputPin = NumberOfRotorPins - ((self.__ringSetting - 1) \
-            - outputPin)
-        else:
-            outputPin -= (self.__ringSetting - 1)
-
-        if outputPin > NumberOfRotorPins:
-            outputPin = outputPin - NumberOfRotorPins;
-            final_contact = output_contact
-#endif
-
-        DebugLog( "Rotor::" + std::string(__func__),
-            "|==== STEP 3: Correct input contact with rotor offset ====|");
+            "|==== STEP 2: Correct input contact with rotor offset ====|");
 
         // STEP 3: Take rotor offset into account
         DebugLog( "Rotor::" + std::string(__func__),

--- a/src/libEnigmaSimulator/Rotor.cpp
+++ b/src/libEnigmaSimulator/Rotor.cpp
@@ -241,13 +241,17 @@ namespace enigmaSimulator {
         auto src = wiring_default_.GetSrcWiringPathStr ();
         auto dest = wiring_default_.GetDestWiringPathStr ();
 
+        // Stage 1 : Modify wiring based on ring position.
         if (ring_position_ > kRotorContact_A)
         {
+            // 1] Get the offset ring (remove 1 to account for position 'a').
             int ring_offset = static_cast<int>(ring_position_)
                 - static_cast<int>(kRotorContact_A);
+            // 2] Rotate all destination wiring 'ring_offset' places right.
             RightRotateString (dest, ring_offset);
-            OffsetStringValue (dest, static_cast<int>(ring_position_)
-                - static_cast<int>(kRotorContact_A));
+            // 3] Offset/increment all destination wiring by 'ring_offset'.
+            //    E.g. with ring_offset of 2, 'A' would become 'C'.
+            OffsetStringValue (dest, ring_offset);
         }
 
         wiring_ = RotorWireConfiguration(dest, src);

--- a/src/libEnigmaSimulator/Rotor.cpp
+++ b/src/libEnigmaSimulator/Rotor.cpp
@@ -41,6 +41,7 @@ namespace enigmaSimulator {
     void Rotor::RotorPosition (RotorContact position)
     {
         rotor_position_ = position;
+        RecalculateWiring ();
     }
 
     // Property getter : Position of the ring.
@@ -218,22 +219,10 @@ namespace enigmaSimulator {
 
     void Rotor::PrettyPrintWiring()
     {
-        int contact = kRotorContact_A;
-        std::string src;
-        std::string dest;
-
-        while (contact <= kRotorContact_Z)
-        {
-            src += RotorContactStr[contact];
-            dest += RotorContactStr[wiring_.WiringPathForward (
-                RotorContact(contact))];
-            contact++;
-        }
-
         TraceLog( kLogLevel_trace,
-                  "Source      : %s", src.c_str());
+                  "Source      : %s", wiring_.GetSrcWiringPathStr().c_str());
         TraceLog( kLogLevel_trace,
-                  "Destination : %s", dest.c_str());
+                  "Destination : %s", wiring_.GetDestWiringPathStr().c_str());
     }
 
     void Rotor::RecalculateWiring ()
@@ -254,13 +243,16 @@ namespace enigmaSimulator {
             OffsetStringValue (dest, ring_offset);
         }
 
+        // Stage 2 : Modify wiring based on rotor position.
+        // 1] Get the rotor offset (remove 1 to account for position 'a').
+        int rotor_offset = static_cast<int>(rotor_position_)
+            - static_cast<int>(kRotorContact_A);
+        // 2] Rotate all source wiring 'rotor_position_' places left.
+        LeftRotateString(src, rotor_offset);
+        // 2] Rotate all destination wiring 'rotor_position_' places left.
+        LeftRotateString(dest, rotor_offset);
+
         wiring_ = RotorWireConfiguration(dest, src);
     }
-
-    // abcdefghijklmnopQrstuvwxyz
-    // ekmflgdqvzntowyhxuspaibrcj
-
-    // abcdefghijklmnopQrstuvwxyz
-    // kflngmherwaoupxziyvtqbjcsd
 
 }   // namespace enigmaSimulator

--- a/src/libEnigmaSimulator/Rotor.h
+++ b/src/libEnigmaSimulator/Rotor.h
@@ -53,7 +53,9 @@ namespace enigmaSimulator {
 
         void Step ();
 
-        RotorContact Encrypt (RotorContact contact, bool forward = true);
+        RotorContact EncryptForward (RotorContact contact);
+
+        RotorContact EncryptReverse (RotorContact contact);
 
         bool WillStepNext ();
 

--- a/src/libEnigmaSimulator/RotorWireConfiguration.h
+++ b/src/libEnigmaSimulator/RotorWireConfiguration.h
@@ -14,7 +14,7 @@
 */
 #ifndef ROTORWIRINGLAYOUT_H
 #define ROTORWIRINGLAYOUT_H
-#include <map>
+#include <vector>
 #include <stdexcept>
 #include <string>
 #include "Definitions.h"
@@ -24,7 +24,7 @@
 
 namespace enigmaSimulator {
 
-    using WiringLayoutMap = std::map<RotorContact, WiringEntry>;
+    using WiringLayout = std::vector<WiringEntry>;
 
     const std::string DEFAULT_SRC_LAYOUT = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -48,10 +48,9 @@ namespace enigmaSimulator {
 
             for (int i = 0; i < src_layout.size (); i++)
             {
-                RotorContact position = RotorContact (i + 1);
                 RotorContact src = RotorContact ((src_layout.c_str ()[i] - 65) + 1);
                 RotorContact dest = RotorContact ((dest_layout.c_str ()[i] - 65) + 1);
-                AddEntry (position, src, dest);
+                AddEntry (src, dest);
             }
         }
 
@@ -63,7 +62,7 @@ namespace enigmaSimulator {
         {
             if (!HasValidWiring ()) throw std::runtime_error ("Invalid wiring");
 
-            return wiring_.find (src)->second.dest;
+            return wiring_[(static_cast<int>(src) - 1)].dest;
         }
 
         RotorContact WiringPathReverse (const RotorContact dest)
@@ -74,9 +73,9 @@ namespace enigmaSimulator {
 
             for (auto it = wiring_.begin (); it != wiring_.end (); ++it)
             {
-                if (it->second.dest == dest)
+                if (it->dest == dest)
                 {
-                    src = it->second.src;
+                    src = it->src;
                 }
             }
 
@@ -97,7 +96,7 @@ namespace enigmaSimulator {
                 return { kRotorContact_end, kRotorContact_end };
             }
 
-            return { wiring_it_->second.src, wiring_it_->second.dest };
+            return { wiring_it_->src, wiring_it_->dest };
         }
 
         void PrettyPrintSrcWiringPath ()
@@ -115,7 +114,7 @@ namespace enigmaSimulator {
             std::string wiring;
             for (auto it = wiring_.begin (); it != wiring_.end (); ++it)
             {
-                wiring.push_back ( RotorContactStr[it->second.src]);
+                wiring.push_back ( RotorContactStr[it->src]);
             }
 
             return wiring;
@@ -126,32 +125,32 @@ namespace enigmaSimulator {
             std::string wiring;
             for (auto it = wiring_.begin (); it != wiring_.end (); ++it)
             {
-                wiring.push_back (RotorContactStr[it->second.dest]);
+                wiring.push_back (RotorContactStr[it->dest]);
             }
 
             return wiring;
         }
 
     private:
-        WiringLayoutMap wiring_;
-        WiringLayoutMap::iterator wiring_it_;
+        WiringLayout wiring_;
+        WiringLayout::iterator wiring_it_;
 
-        void AddEntry (RotorContact position, RotorContact src, RotorContact dest)
+        void AddEntry (RotorContact src, RotorContact dest)
         {
             for (auto it = wiring_.begin (); it != wiring_.end (); ++it)
             {
-                if (it->second.src == src)
+                if (it->src == src)
                 {
                     throw std::runtime_error ("Duplicate src wiring contact!");
                 }
 
-                if (it->second.dest == dest)
+                if (it->dest == dest)
                 {
                     throw std::runtime_error ("Duplicate destination wiring contact!");
                 }
             }
 
-            wiring_.insert ({ position, {src, dest} });
+            wiring_.push_back ( {src, dest} );
         }
 
     };

--- a/src/libEnigmaSimulator/main.cpp
+++ b/src/libEnigmaSimulator/main.cpp
@@ -12,6 +12,8 @@
 #include "Logging.h"
 #include "StringUtils.h"
 
+using namespace enigmaSimulator;
+
 void LogDebugMessage(std::string functionName, std::string msg, bool clipped)
 {
     std::cout << "[DEBUG] " << functionName << "() " << msg << std::endl;
@@ -62,9 +64,19 @@ int main (int argc, char** argv)
 
     try
     {
-        //machine.RotorPosition (enigmaSimulator::kRotorPositionNumber_1,
-        //    enigmaSimulator::kRotorContact_B);
-        machine.RingSetting (enigmaSimulator::kRotorPositionNumber_2, enigmaSimulator::kRotorContact_C);
+        printf("[PRESET] Setting Rotor 1 rotor position to 'B'\n");
+        machine.RotorPosition (enigmaSimulator::kRotorPositionNumber_1,
+            enigmaSimulator::kRotorContact_C);
+        machine.RotorPosition (enigmaSimulator::kRotorPositionNumber_2,
+            enigmaSimulator::kRotorContact_Z);
+
+        printf("[PRESET] Setting Rotor 2 ring position to 'C'\n");
+        machine.RingSetting (
+            enigmaSimulator::kRotorPositionNumber_1,
+            enigmaSimulator::kRotorContact_Y);
+        machine.RingSetting (
+            enigmaSimulator::kRotorPositionNumber_2,
+            enigmaSimulator::kRotorContact_G);
     }
     catch (std::exception& ex)
     {

--- a/src/libEnigmaSimulatorTests/RotorTests.cpp
+++ b/src/libEnigmaSimulatorTests/RotorTests.cpp
@@ -71,12 +71,12 @@ TEST_F(RotorTest, EncryptNoPositionOrRingOffset)
         valid_wiring_layout_,
         std::vector<enigmaSimulator::RotorContact>());
 
-    auto output = rotor.Encrypt(enigmaSimulator::kRotorContact_A);
+    auto output = rotor.EncryptForward(enigmaSimulator::kRotorContact_A);
     EXPECT_EQ(output, enigmaSimulator::kRotorContact_E)
         << "Expecting 'E', got '"
         << enigmaSimulator::RotorContactStr[output] << "'";
 
-    output = rotor.Encrypt(enigmaSimulator::kRotorContact_A, false);
+    output = rotor.EncryptReverse(enigmaSimulator::kRotorContact_A);
     EXPECT_EQ(output, enigmaSimulator::kRotorContact_U)
         << "Expecting 'E', got '"
         << enigmaSimulator::RotorContactStr[output] << "'";
@@ -102,16 +102,16 @@ TEST_F(RotorTest, EncryptPositionChangedSimpleNoRingOffset)
 
     // Forward test
     rotor.RotorPosition(enigmaSimulator::kRotorContact_B);
-    auto output = rotor.Encrypt(enigmaSimulator::kRotorContact_A);
+    auto output = rotor.EncryptForward(enigmaSimulator::kRotorContact_A);
     EXPECT_EQ(output, enigmaSimulator::kRotorContact_J)
         << "Expecting 'J', got '"
         << enigmaSimulator::RotorContactStr[output] << "'";
 
     // Reverse test
-    output = rotor.Encrypt(enigmaSimulator::kRotorContact_A, false);
-    EXPECT_EQ(output, enigmaSimulator::kRotorContact_V)
-        << "Expecting 'V', got '"
-        << enigmaSimulator::RotorContactStr[output] << "'";
+    output = rotor.EncryptReverse(enigmaSimulator::kRotorContact_H);
+    EXPECT_EQ(output, enigmaSimulator::kRotorContact_U)
+        << "From 'I' expecting 'U', got " << enigmaSimulator::RotorContactStr[output];
+
 
     /*
     Test encrypting a letter with a longer position change, the position is
@@ -125,7 +125,7 @@ TEST_F(RotorTest, EncryptPositionChangedSimpleNoRingOffset)
     on the way out it is offset -5 positions, therefore 'B' is returned.
     */
     rotor.RotorPosition(enigmaSimulator::kRotorContact_F);
-    output = rotor.Encrypt(enigmaSimulator::kRotorContact_A);
+    output = rotor.EncryptForward(enigmaSimulator::kRotorContact_A);
 
     ASSERT_EQ(output, enigmaSimulator::kRotorContact_B)
         << "Expecting 'B', got '"
@@ -145,7 +145,7 @@ TEST_F(RotorTest, EncryptPositionChangedSimpleNoRingOffset)
     on the way out it is at a -6 position, therefore 'B' is returned.
     */
     rotor.RotorPosition(enigmaSimulator::kRotorContact_D);
-    output = rotor.Encrypt(enigmaSimulator::kRotorContact_X);
+    output = rotor.EncryptForward(enigmaSimulator::kRotorContact_X);
 
     ASSERT_EQ(output, enigmaSimulator::kRotorContact_B)
         << "Expected 'B', got '"
@@ -182,19 +182,19 @@ TEST_F(RotorTest, EncryptNoPositionChangedHasRingOffset)
 
     // Forward test 1 / 2
     rotor.RingPosition(enigmaSimulator::kRotorContact_C);
-    auto fwdOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_G);
+    auto fwdOut1 = rotor.EncryptForward(enigmaSimulator::kRotorContact_G);
     EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_N)
         << "From 'G' expecting 'N', got " << enigmaSimulator::RotorContactStr[fwdOut1];
 
     // Forward test 2 / 2
     rotor.RingPosition(enigmaSimulator::kRotorContact_Z);
-    auto fwdOut2 = rotor.Encrypt(enigmaSimulator::kRotorContact_K);
+    auto fwdOut2 = rotor.EncryptForward(enigmaSimulator::kRotorContact_K);
     EXPECT_EQ(fwdOut2, enigmaSimulator::kRotorContact_S)
         << "From 'K' expecting 'S', got " << enigmaSimulator::RotorContactStr[fwdOut2];
 
     // Reverse test
     rotor.RingPosition(enigmaSimulator::kRotorContact_C);
-    auto revOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_C, false);
+    auto revOut1 = rotor.EncryptReverse(enigmaSimulator::kRotorContact_C);
     EXPECT_EQ(revOut1, enigmaSimulator::kRotorContact_W)
         << "From 'C' expecting 'W', got '"
         << enigmaSimulator::RotorContactStr[revOut1] << "'";
@@ -210,15 +210,16 @@ TEST_F(RotorTest, EncryptPositionChangedHasRingOffset)
     // Forward test 1
     rotor.RingPosition(enigmaSimulator::kRotorContact_C);
     rotor.RotorPosition(enigmaSimulator::kRotorContact_G);
-    auto fwdOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_G);
-    EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_N)
-        << "Pos: 'G', Ring: 'C' From 'G' expecting 'N', got "
+    auto fwdOut1 = rotor.EncryptForward(enigmaSimulator::kRotorContact_G);
+    EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_J)
+        << "Pos: 'G', Ring: 'C' From 'G' expecting 'J', got "
         << enigmaSimulator::RotorContactStr[fwdOut1];
 
     // Reverse test
-    //rotor.RingPosition(enigmaSimulator::kRotorContact_C);
-    auto revOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_C, false);
+    rotor.RingPosition(enigmaSimulator::kRotorContact_C);
+    rotor.RotorPosition(enigmaSimulator::kRotorContact_C);
+    auto revOut1 = rotor.EncryptReverse(enigmaSimulator::kRotorContact_Z);
     EXPECT_EQ(revOut1, enigmaSimulator::kRotorContact_W)
-        << "Pos: 'G', Ring: 'C' From 'G' expecting 'N', got "
+        << "Pos: 'J', Ring: 'Y' From 'Z' expecting 'N', got "
         << enigmaSimulator::RotorContactStr[fwdOut1];
 }

--- a/src/libEnigmaSimulatorTests/RotorTests.cpp
+++ b/src/libEnigmaSimulatorTests/RotorTests.cpp
@@ -172,3 +172,52 @@ TEST_F(RotorTest, EncryptPositionChangedSimpleNoRingOffset)
         self._valid_pass_through_rotor.step()
         self.assertEqual(self._valid_pass_through_rotor.position, 1)
 */
+
+/*
+abcdefghijklmnopQrstuvwxyz
+ekmflgdqvzntowyhxuspaibrcj
+
+abcdefghijklmnopQrstuvwxyz
+kflngmherwaoupxziyvtqbjcsd
+*/
+
+TEST_F(RotorTest, EncryptNoPositionChangedHasRingOffset)
+{
+    auto rotor = enigmaSimulator::Rotor(
+        "Rotor 1",
+        valid_wiring_layout_,
+        std::vector<enigmaSimulator::RotorContact>());
+
+    // Forward test 1 / 2
+    rotor.RingPosition(enigmaSimulator::kRotorContact_C);
+    auto fwdOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_G);
+    EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_N)
+        << "From 'G' expecting 'N', got " << enigmaSimulator::RotorContactStr[fwdOut1];
+
+    // Forward test 2 / 2
+    rotor.RingPosition(enigmaSimulator::kRotorContact_Z);
+    auto fwdOut2 = rotor.Encrypt(enigmaSimulator::kRotorContact_K);
+    EXPECT_EQ(fwdOut2, enigmaSimulator::kRotorContact_S)
+        << "From 'K' expecting 'S', got " << enigmaSimulator::RotorContactStr[fwdOut2];
+
+    // Reverse test
+    rotor.RingPosition(enigmaSimulator::kRotorContact_C);
+    auto revOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_C, false);
+    EXPECT_EQ(revOut1, enigmaSimulator::kRotorContact_W)
+        << "From 'C' expecting 'W', got '"
+        << enigmaSimulator::RotorContactStr[revOut1] << "'";
+}
+
+/*
+abcdefghijklmnopQrstuvwxyz
+ekmflgdqvzntowyhxuspaibrcj
+
+abcdefghijklmnopQrstuvwxyz
+kflngmherwaoupxziyvtqbjcsd
+
+M == F ???
+
+Input - 1 : 'M' => 'K'
+*/
+
+/// g -> c

--- a/src/libEnigmaSimulatorTests/RotorTests.cpp
+++ b/src/libEnigmaSimulatorTests/RotorTests.cpp
@@ -173,14 +173,6 @@ TEST_F(RotorTest, EncryptPositionChangedSimpleNoRingOffset)
         self.assertEqual(self._valid_pass_through_rotor.position, 1)
 */
 
-/*
-abcdefghijklmnopQrstuvwxyz
-ekmflgdqvzntowyhxuspaibrcj
-
-abcdefghijklmnopQrstuvwxyz
-kflngmherwaoupxziyvtqbjcsd
-*/
-
 TEST_F(RotorTest, EncryptNoPositionChangedHasRingOffset)
 {
     auto rotor = enigmaSimulator::Rotor(
@@ -208,16 +200,25 @@ TEST_F(RotorTest, EncryptNoPositionChangedHasRingOffset)
         << enigmaSimulator::RotorContactStr[revOut1] << "'";
 }
 
-/*
-abcdefghijklmnopQrstuvwxyz
-ekmflgdqvzntowyhxuspaibrcj
+TEST_F(RotorTest, EncryptPositionChangedHasRingOffset)
+{
+    auto rotor = enigmaSimulator::Rotor(
+    "Rotor 1",
+    valid_wiring_layout_,
+    std::vector<enigmaSimulator::RotorContact>());
 
-abcdefghijklmnopQrstuvwxyz
-kflngmherwaoupxziyvtqbjcsd
+    // Forward test 1
+    rotor.RingPosition(enigmaSimulator::kRotorContact_C);
+    rotor.RotorPosition(enigmaSimulator::kRotorContact_G);
+    auto fwdOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_G);
+    EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_N)
+        << "Pos: 'G', Ring: 'C' From 'G' expecting 'N', got "
+        << enigmaSimulator::RotorContactStr[fwdOut1];
 
-M == F ???
-
-Input - 1 : 'M' => 'K'
-*/
-
-/// g -> c
+    // Reverse test
+    //rotor.RingPosition(enigmaSimulator::kRotorContact_C);
+    auto revOut1 = rotor.Encrypt(enigmaSimulator::kRotorContact_C, false);
+    EXPECT_EQ(revOut1, enigmaSimulator::kRotorContact_W)
+        << "Pos: 'G', Ring: 'C' From 'G' expecting 'N', got "
+        << enigmaSimulator::RotorContactStr[fwdOut1];
+}

--- a/src/libEnigmaSimulatorTests/RotorTests.cpp
+++ b/src/libEnigmaSimulatorTests/RotorTests.cpp
@@ -210,16 +210,17 @@ TEST_F(RotorTest, EncryptPositionChangedHasRingOffset)
     // Forward test 1
     rotor.RingPosition(enigmaSimulator::kRotorContact_C);
     rotor.RotorPosition(enigmaSimulator::kRotorContact_G);
-    auto fwdOut1 = rotor.EncryptForward(enigmaSimulator::kRotorContact_G);
-    EXPECT_EQ(fwdOut1, enigmaSimulator::kRotorContact_J)
-        << "Pos: 'G', Ring: 'C' From 'G' expecting 'J', got "
-        << enigmaSimulator::RotorContactStr[fwdOut1];
+    auto fwdOut = rotor.EncryptForward(enigmaSimulator::kRotorContact_G);
+    EXPECT_EQ(fwdOut, enigmaSimulator::kRotorContact_J)
+        << "Pressed 'G' : Ring: 'C' From 'G' expecting 'J', got "
+        << enigmaSimulator::RotorContactStr[fwdOut];
 
     // Reverse test
     rotor.RingPosition(enigmaSimulator::kRotorContact_C);
     rotor.RotorPosition(enigmaSimulator::kRotorContact_C);
-    auto revOut1 = rotor.EncryptReverse(enigmaSimulator::kRotorContact_Z);
-    EXPECT_EQ(revOut1, enigmaSimulator::kRotorContact_W)
-        << "Pos: 'J', Ring: 'Y' From 'Z' expecting 'N', got "
-        << enigmaSimulator::RotorContactStr[fwdOut1];
+
+    auto revOut = rotor.EncryptReverse(enigmaSimulator::kRotorContact_W);
+    EXPECT_EQ(revOut, enigmaSimulator::kRotorContact_N)
+        << "Pressed 'W' : Ring: 'C' From 'C' expecting 'N', got "
+        << enigmaSimulator::RotorContactStr[revOut];
 }


### PR DESCRIPTION
Changes:
* Updated readme to include what has been implemented
* Fixed ring position
* Added rotor unit tests for ring position
* Split Rotor::Encrypt() into EncryptForward() and EncryptReverse()
* When setting the rotor position, RecalculateWiring() is now called
* Fixed Rotor::PrettyPrintWiring()
* RotorWiring changed from map to vector